### PR TITLE
Add support for Ampere eMAG core and uncore PMUs

### DIFF
--- a/daemon/events-Ampere-eMAG-L3C.xml
+++ b/daemon/events-Ampere-eMAG-L3C.xml
@@ -1,0 +1,46 @@
+<!-- Copyright (c) 2018, Ampere Computing LLC -->
+<!-- SPDX-License-Identifier: GPL-2.0-only -->
+ <counter_set name="L3C_cnt" count="4"/>
+  <category name="L3C" counter_set="L3C_cnt" per_cpu="no">
+    <!--CYCLES-->
+    <event counter="L3C_ccnt" title="L3C Clock" event="0x0000" name="Cycles" description="Cycle counter." display="hertz" units="Hz" average_selection="yes" />
+    <!--L3_CACHE-->
+    <event title="L3 Cache" event="0x0001" name="Read hit" description="Read is a hit." />
+    <event title="L3 Cache" event="0x0002" name="Read miss" description="Read is a miss." />
+    <event title="L3 Cache" event="0x0003" name="Index flush eviction" description="Index flush causes a (dirty) eviction." />
+    <event title="L3 Cache" event="0x0004" name="Write caused replacement" description="Write causes a replacement." />
+    <event title="L3 Cache" event="0x0005" name="Write did not cause replacement" description="Write causes no replacement." />
+    <event title="L3 Cache" event="0x0006" name="Clean (eviction)" description="A clean line was replaced." />
+    <event title="L3 Cache" event="0x0007" name="Dirty (eviction)" description="A dirty line was replaced and evicted." />
+    <event title="L3 Cache" event="0x0008" name="Reads" description="Csw reads." />
+    <event title="L3 Cache" event="0x0009" name="Writes" description="Csw writes." />
+    <event title="L3 Cache" event="0x000a" name="Requests" description="Csw requests = Csw Reads + Csw Writes + Csw other ops." />
+    <event title="L3 Cache" event="0x000b" name="TQ bank conflict issue stall" description="The TQ can't issue due to a bank conflict." />
+    <event title="L3 Cache" event="0x000c" name="TQ full" description="TQ is full." />
+    <event title="L3 Cache" event="0x000d" name="ACKQ full" description="ACKQ is full." />
+    <event title="L3 Cache" event="0x000e" name="WDB full" description="WDB is full." />
+    <event title="L3 Cache" event="0x0010" name="ODB full" description="ODB is full." />
+    <event title="L3 Cache" event="0x0011" name="WBQ full" description="WBQ is full." />
+    <event title="L3 Cache" event="0x0012" name="Input request async FIFO stall" description="The Csw input request async FIFO is stalled." />
+    <event title="L3 Cache" event="0x0013" name="Output request async FIFO stall" description="The Csw output request async FIFO is stalled." />
+    <event title="L3 Cache" event="0x0014" name="Output data async FIFO stall" description="The Csw output data FIFO is stalled." />
+    <event title="L3 Cache" event="0x0015" name="Total insertions (==writes)" description="L2c writebacks." />
+    <event title="L3 Cache" event="0x0016" name="SIP insertions with R bit set" description="SIP insertions with R bit set." />
+    <event title="L3 Cache" event="0x0017" name="SIP insertions with R bit clear" description="SIP insertions with R bit clear." />
+    <event title="L3 Cache" event="0x0018" name="DIP insertions with R bit set" description="DIP insertions with R bit set." />
+    <event title="L3 Cache" event="0x0019" name="DIP insertions with R bit clear" description="DIP insertions with R bit clear." />
+    <event title="L3 Cache" event="0x001a" name="DIP insertions force R bit set" description="DIP insertions where filter predicts not to set R bit and DIP sets it." />
+    <event title="L3 Cache" event="0x001b" name="Egressions" description="Egressions." />
+    <event title="L3 Cache" event="0x001c" name="Replacements" description="Clean or dirty data is replaced." />
+    <event title="L3 Cache" event="0x001d" name="Old replacements" description="Replaced data is marked old." />
+    <event title="L3 Cache" event="0x001e" name="Young replacements" description="Replaced data is marked young." />
+    <event title="L3 Cache" event="0x001f" name="R bit set replacements" description="Replaced data is marked R=1." />
+    <event title="L3 Cache" event="0x0020" name="R bit clear replacements" description="Replaced data is marked R=0." />
+    <event title="L3 Cache" event="0x0021" name="Old R replacements" description="Replaced data is marked old and R=1." />
+    <event title="L3 Cache" event="0x0022" name="Old NR replacements" description="Replaced data is marked old and R=0." />
+    <event title="L3 Cache" event="0x0023" name="Young R replacements" description="Replaced data is marked young and R=1." />
+    <event title="L3 Cache" event="0x0024" name="Young NR replacements" description="Replaced data is marked young and R=0." />
+    <event title="L3 Cache" event="0x0025" name="Bloom filter clearings" description="Bloom filter clearings." />
+    <event title="L3 Cache" event="0x0026" name="Generation flips" description="Generation flips." />
+    <event title="L3 Cache" event="0x0027" name="Voltage droop detected" description="Voltage droop detected by L3C voltage droop detector." />
+  </category>

--- a/daemon/events-Ampere-eMAG-MCB.xml
+++ b/daemon/events-Ampere-eMAG-MCB.xml
@@ -1,0 +1,58 @@
+<!-- Copyright (c) 2018, Ampere Computing LLC -->
+<!-- SPDX-License-Identifier: GPL-2.0-only -->
+ <counter_set name="MCB_cnt" count="4"/>
+  <category name="MCB" counter_set="MCB_cnt" per_cpu="no">
+    <!--CYCLES-->
+    <event counter="MCB_ccnt" title="MCB Clock" event="0x0000" name="Cycles" description="Cycle counter." display="hertz" units="Hz" average_selection="yes" />
+    <!--Memory Subsystem-->
+    <event title="Memory Subsystem" event="0x0001" name="Req recv" description="Request (Read or Write) Received from CSW." />
+    <event title="Memory Subsystem" event="0x0002" name="Rd req recv" description="Read Request Received from CSW." />
+    <event title="Memory Subsystem" event="0x0003" name="Rd req recv-2" description="Read Request Received from CSW (Same as Event 02)." />
+    <event title="Memory Subsystem" event="0x0004" name="Wr req recv" description="Write Request Received from CSW." />
+    <event title="Memory Subsystem" event="0x0005" name="Wr req recv-2" description="Write Request Received from CSW (Same as Event 04)." />
+    <event title="Memory Subsystem" event="0x0006" name="Rd req sent to MCU" description="Initial (not retry) read request sent to MCU#n." />
+    <event title="Memory Subsystem" event="0x0007" name="Rd req sent to MCU-2" description="Initial (not retry) read request sent to MCU#n (same as event 06)." />
+    <event title="Memory Subsystem" event="0x0008" name="Rd req sent spec to MCU" description="A read request is sent before Global Ack received (i.e. speculatively) to MCU#n." />
+    <event title="Memory Subsystem" event="0x0009" name="Rd req sent spec to MCU-2" description="A read request is sent before Global Ack received (i.e. speculatively) to MCU#n (Same as event 08)." />
+    <event title="Memory Subsystem" event="0x000a" name="Glbl ack recv for rd req sent spec to MCU" description="Global Ack received for read request previously sent (speculatively) to MCU#n." />
+    <event title="Memory Subsystem" event="0x000b" name="Glbl ack go for rd req sent spec to MCU" description="Global Ack “Go” received for read request previously sent (speculatively) to MCU#n." />
+    <event title="Memory Subsystem" event="0x000c" name="Glbl ack nogo for rd req sent spec to MCU" description="Global Ack “NoGo” received for read request previously sent (speculatively) to MCU#n." />
+    <event title="Memory Subsystem" event="0x000d" name="Glbl ack go for any rd req" description="Global Ack “Go” received for any read request, either sent previously or not." />
+    <event title="Memory Subsystem" event="0x000e" name="Glbl ack go for any rd req-2" description="Global Ack “Go” received for any read request, either sent previously or not." />
+    <event title="Memory Subsystem" event="0x000f" name="Wr request sent to MCU" description="Initial (not retry) write request sent to MCU#n." />
+    <event title="Memory Subsystem" event="0x0010" name="GAck recv" description="Global Ack Received from CSW." />
+    <event title="Memory Subsystem" event="0x0011" name="Rd GAck recv" description="Global Ack For Read Received from CSW." />
+    <event title="Memory Subsystem" event="0x0012" name="Wr GAck recv" description="Global Ack For Read Received from CSW." />
+    <event title="Memory Subsystem" event="0x0013" name="Cancel rd GAck" description="MCB receives Global Ack from CSW indicating cancelled read." />
+    <event title="Memory Subsystem" event="0x0014" name="Cancel wr GAck" description="MCB receives Global Ack from CSW indicating cancelled write." />
+    <event title="Memory Subsystem" event="0x0015" name="MCB-CSW req stall" description="MCB stalls CSW Request Interface." />
+    <event title="Memory Subsystem" event="0x0016" name="MCU req intf blocked" description="Mcb to Mcu Request interface stall." />
+    <event title="Memory Subsystem" event="0x0017" name="MCB-MCU rd intf stall" description="Mcb stalls MCU#n read data interface." />
+    <event title="Memory Subsystem" event="0x0018" name="CSW rd intf blocked" description="The CSW read data response Async FIFO interface is blocked." />
+    <event title="Memory Subsystem" event="0x0019" name="CSW local ack intf blocked" description="The CSW Local Ack response Async FIFO interface is blocked." />
+    <event title="Memory Subsystem" event="0x001a" name="MCU req table full" description="The MCU#n Request Table is full." />
+    <event title="Memory Subsystem" event="0x001b" name="MCU status table full" description="The MCU#n Status Table is full." />
+    <event title="Memory Subsystem" event="0x001c" name="MCU write table full" description="The MCU#n  Write Data Table is full." />
+    <event title="Memory Subsystem" event="0x001d" name="MCU rdreceipt resp" description="READRECEIPT response received from MCU#n." />
+    <event title="Memory Subsystem" event="0x001e" name="MCU wrcomplete resp" description="WRITECOMPLETE response received from MCU#n ." />
+    <event title="Memory Subsystem" event="0x001f" name="MCU retryack resp" description="RETRYACK response received from MCU#n." />
+    <event title="Memory Subsystem" event="0x0020" name="MCU pcrdgrant resp" description="PCRDGRANT response from MCU#n." />
+    <event title="Memory Subsystem" event="0x0021" name="MCU req from lastload" description="Request sent to MCU#n from LastLoad register." />
+    <event title="Memory Subsystem" event="0x0022" name="MCU req from bypass" description="Request sent to MCU#n as bypass from CSW." />
+    <event title="Memory Subsystem" event="0x0023" name="Voltage droop detect" description="Voltage Droop Detected in MCB." />
+    <event title="Memory Subsystem" event="0x0031" name="Req to GAck latency" description="Latency from Any Request Received (event 01) to Global Ack." />
+    <event title="Memory Subsystem" event="0x0032" name="Rd req to LAck latency" description="Latency from Read Request Received (event 02) to Local Ack for Read." />
+    <event title="Memory Subsystem" event="0x0033" name="Rd req to GAck latency" description="Latency from Read Request Received (event 03) to Global Ack for Read." />
+    <event title="Memory Subsystem" event="0x0034" name="Wr req to LAck latency" description="Latency from Read Request Received (event 04) to Local Ack for Write." />
+    <event title="Memory Subsystem" event="0x0035" name="Wr req to GAck latency" description="Latency from Write Request (event 05) to Global Ack for Write." />
+    <event title="Memory Subsystem" event="0x0036" name="Sent MCU rd req to cmpl or cancel" description="Latency from Read Send (event 06) to MCU Read Receipt or request cancellation." />
+    <event title="Memory Subsystem" event="0x0037" name="Sent MCU rd req to final cmpl" description="Latency from Read Send (event 07) to final completion of processing (i.e. Status Table entry retired)." />
+    <event title="Memory Subsystem" event="0x0038" name="Spec sent MCU rd req to GAck latency" description="Latency from Speculative Read Send (event 08) to Global Ack received." />
+    <event title="Memory Subsystem" event="0x0039" name="Spec sent MCU rd req to final cmpl latency" description="Latency from Speculative Read Send (event 09) to final completion of processing (i.e. Status Table entry retired)." />
+    <event title="Memory Subsystem" event="0x003a" name="GAck recv for spec sent rd to req cmpl" description="Latency from Global Ack Received for speculatively sent read (event 10) to final completion of processing (i.e. Status Table entry retired).  Both successful and dropped requests counted." />
+    <event title="Memory Subsystem" event="0x003b" name="GAck go recv for spec sent to rd req cmpl" description="Latency from Global Ack “Go”Received for speculatively sent read (event 11) to final completion of processing (i.e. Status Table entry retired).  Only successful requests counted." />
+    <event title="Memory Subsystem" event="0x003c" name="GAck nogo recv for spec sent to rd req cmpl" description="Latency from Global Ack “NoGo”Received for speculatively sent read (event 12) to final completion of processing (i.e. Status Table entry retired).  Only dropped requests counted." />
+    <event title="Memory Subsystem" event="0x003d" name="GAck go recv for any rd req sent to req cmpl" description="Latency from Global Ack “Go”Received for any read (event 13) to final completion of processing (i.e. Status Table entry retired).  Only successful requests counted." />
+    <event title="Memory Subsystem" event="0x003e" name="GAck go recv for any rd req to rd returned latency" description="Latency from Global Ack “Go”Received for any read (event 14) to Read Data returned to CSW.    Only successful requests counted." />
+    <event title="Memory Subsystem" event="0x003f" name="Wr req sent to wr cmpl for MCU latency" description="Latency from Write Request Sent to MCU#n (event 15) to write complete." />
+  </category>

--- a/daemon/events-Ampere-eMAG-MCU.xml
+++ b/daemon/events-Ampere-eMAG-MCU.xml
@@ -1,0 +1,50 @@
+<!-- Copyright (c) 2018, Ampere Computing LLC -->
+<!-- SPDX-License-Identifier: GPL-2.0-only -->
+ <counter_set name="MCU_cnt" count="4"/>
+  <category name="MCU" counter_set="MCU_cnt" per_cpu="no">
+    <!--CYCLES-->
+    <event counter="MCU_ccnt" title="MCU Clock" event="0x0000" name="Cycles" description="Cycle counter." display="hertz" units="Hz" average_selection="yes" />
+    <!--Memory Controller-->
+    <event title="Memory Controller" event="0x0001" name="Act sent" description="DMC sent ACT command on DFI." />
+    <event title="Memory Controller" event="0x0002" name="Pre sent" description="DMC sent PRE command on DFI." />
+    <event title="Memory Controller" event="0x0003" name="Rd sent" description="DMC sent RD command on DFI." />
+    <event title="Memory Controller" event="0x0004" name="Rda sent" description="DMC sent RDA command on DFI." />
+    <event title="Memory Controller" event="0x0005" name="Wr sent" description="DMC sent WR command on DFI." />
+    <event title="Memory Controller" event="0x0006" name="Wra sent" description="DMC sent WRA command on DFI." />
+    <event title="Memory Controller" event="0x0007" name="Pd entry valid" description="PDE sent." />
+    <event title="Memory Controller" event="0x0008" name="Sref entry valid" description="SRE sent." />
+    <event title="Memory Controller" event="0x0009" name="Prea sent" description="DMC sent PREA command on DFI." />
+    <event title="Memory Controller" event="0x000a" name="Ref sent" description="DMC sent REF command on DFI." />
+    <event title="Memory Controller" event="0x000b" name="Rd or Rda sent" description="DMC sent RD or RDA command on DFI." />
+    <event title="Memory Controller" event="0x000c" name="Wr or Wra sent" description="DMC sent WR or WRA command on DFI." />
+    <event title="Memory Controller" event="0x000d" name="RAW hazard" description="Read collision with prior write." />
+    <event title="Memory Controller" event="0x000e" name="WAR hazard" description="Write collision with prior read." />
+    <event title="Memory Controller" event="0x000f" name="WAW hazard" description="Write collision with prior write." />
+    <event title="Memory Controller" event="0x0010" name="RAR hazard" description="Read collision with prior read." />
+    <event title="Memory Controller" event="0x0011" name="RAW or WAR or WAW hazard" description="Any wr/rd or rd/wr collision." />
+    <event title="Memory Controller" event="0x0012" name="HpRd or LpRd or Wr req valid" description="DMC rd/wr request valid." />
+    <event title="Memory Controller" event="0x0013" name="LpRd req valid" description="DMC read request valid, Qos == 0." />
+    <event title="Memory Controller" event="0x0014" name="HpRd req valid" description="DMC read request valid, QoS != 0." />
+    <event title="Memory Controller" event="0x0015" name="HpRd or LpRd req valid" description="DMC read request valid." />
+    <event title="Memory Controller" event="0x0016" name="Wr req valid" description="DMC write request valid." />
+    <event title="Memory Controller" event="0x0017" name="Partial Wr req valid" description="DMC partial write request valid." />
+    <event title="Memory Controller" event="0x0018" name="Rd retry" description="DMC read request given retry response." />
+    <event title="Memory Controller" event="0x0019" name="Wr retry" description="DMC write request given retry response." />
+    <event title="Memory Controller" event="0x001a" name="Retry grant" description="DMC sent retry grant to MCB." />
+    <event title="Memory Controller" event="0x001b" name="Rank change" description="DMC signaling a rank change." />
+    <event title="Memory Controller" event="0x001c" name="Dir change" description="DMC signaling a rd/wr turnaround." />
+    <event title="Memory Controller" event="0x001d" name="Rank Dir change" description="DMC signaling a rd/wr turnaround with rank change." />
+    <event title="Memory Controller" event="0x001e" name="Rank active" description="DMC signaling that selected rank(s) are active." />
+    <event title="Memory Controller" event="0x001f" name="Rank idle" description="DMC signals that selected rank(s) are idle." />
+    <event title="Memory Controller" event="0x0020" name="Rank in Pd" description="DMC signals that the selected rank(s) are in power-down." />
+    <event title="Memory Controller" event="0x0021" name="Rank in Sref" description="DMC signals that the selected rank(s) are in self-refresh." />
+    <event title="Memory Controller" event="0x0022" name="Queue fill gt thresh" description="DMC entry count is greater than threashold." />
+    <event title="Memory Controller" event="0x0023" name="Queued Rds gt thresh" description="DMC read entry count is greater than threshold." />
+    <event title="Memory Controller" event="0x0024" name="Queued Wrs gt thresh" description="DMC write entry count is greater than threshold." />
+    <event title="Memory Controller" event="0x0025" name="Phy updt cmplt" description="DMC signals that a Phy update has been completed." />
+    <event title="Memory Controller" event="0x0026" name="Tz fail" description="DMC signals that a correctable error was detected in the indicated rank and bank." />
+    <event title="Memory Controller" event="0x0027" name="Dram errC" description="DMC signals that a correctable error was detected in the indicated rank and bank." />
+    <event title="Memory Controller" event="0x0028" name="Dram errd" description="DMC signals that an uncorrectable error was detected in the indicated rank and bank." />
+    <event title="Memory Controller" event="0x0029" name="Tmac limit reached" description="DMC signals that a bank row has reached the tMAC threshold for triggering a Target Row Refresh." />
+    <event title="Memory Controller" event="0x002a" name="Tmaw tracker full" description="DMC signals that the tMAC/tMAW tracking resource is full." />
+  </category>

--- a/daemon/events-Ampere-eMAG.xml
+++ b/daemon/events-Ampere-eMAG.xml
@@ -1,0 +1,113 @@
+<!-- Copyright (c) 2018, Ampere Computing LLC -->
+<!-- SPDX-License-Identifier: GPL-2.0-only -->
+ <counter_set name="ARMv8_Ampere_eMAG_cnt" count="6"/>
+  <category name="Ampere_eMAG" counter_set="ARMv8_Ampere_eMAG_cnt" per_cpu="yes" supports_event_based_sampling="yes">
+    <event counter="ARMv8_Ampere_eMAG_ccnt" event="0x11" title="Clock" name="CPU_CYCLES" display="hertz" units="Hz" average_selection="yes" average_cores="yes" description="The number of core clock cycles"/>
+    <event event="0x00" title="Instruction" name="SW_INCR" description="Instruction architecturally executed, software increment"/>
+    <event event="0x01" title="Cache" name="L1I_CACHE_REFILL" description="Level 1 instruction cache refill"/>
+    <event event="0x02" title="Cache" name="L1I_TLB_REFILL" description="Level 1 instruction TLB refill"/>
+    <event event="0x03" title="Cache" name="L1D_CACHE_REFILL" description="Level 1 data cache refill"/>
+    <event event="0x04" title="Cache" name="L1D_CACHE_ACCESS" description="Level 1 data cache access"/>
+    <event event="0x05" title="Cache" name="L1D_TLB_REFILL" description="Level 1 data TLB refill"/>
+    <event event="0x08" title="Instruction" name="INST_RETIRED" description="Instruction architecturally executed"/>
+    <event event="0x09" title="Exception" name="EXC_TAKEN" description="Exception taken"/>
+    <event event="0x0a" title="Exception" name="EXC_RETURN" description="Instruction architecturally executed, condition code check pass, exception return"/>
+    <event event="0x0b" title="Instruction" name="CID_WRITE_RETIRED" description="Instruction architecturally executed, condition code check pass, write to CONTEXTIDR"/>
+    <event event="0x10" title="Branch" name="BR_MIS_PRED" description="Mispredicted or not predicted branch speculatively executed"/>
+    <event event="0x12" title="Branch" name="BR_PRED" description="Predictable branch speculatively executed"/>
+    <event event="0x13" title="Memory" name="MEM_ACCESS" description="Data memory access"/>
+    <event event="0x14" title="Cache" name="L1I_CACHE_ACCESS" description="Level 1 instruction cache access"/>
+    <event event="0x16" title="Cache" name="L2D_CACHE_ACCESS" description="Level 2 data cache access"/>
+    <event event="0x17" title="Cache" name="L2D_CACHE_REFILL" description="Level 2 data cache refill"/>
+    <event event="0x18" title="Cache" name="L2D_CACHE_WB" description="L2 data cache Write-Back"/>
+    <event event="0x19" title="Bus" name="BUS_ACCESS" description="Bus access"/>
+    <event event="0x1a" title="Memory" name="MEM_ERROR" description="Local memory error. This event counts any correctable or uncorrectable memory error (ECC or parity) in the protected core RAMs"/>
+    <event event="0x1b" title="Instruction" name="INST_SPEC" description="Operation speculatively executed"/>
+    <event event="0x1c" title="Instruction" name="TTBR_WRITE_RETIRED" description="Instruction architecturally executed (condition check pass) - Write to TTBR"/>
+    <event event="0x1e" title="Counter" name="CHAIN" description="For odd-numbered counters, increments the count by one for each overflow of the preceding even-numbered counter. For even-numbered counters there is no increment"/>
+    <event event="0x21" title="Instruction" name="BR_RETIRED" description="Instruction architecturally executed, branch. This event counts all branches, taken or not. This excludes exception entries, debug entries and CCFAIL branches"/>
+    <event event="0x22" title="Instruction" name="BR_MISPRED_RETIRED" description="Instruction architecturally executed, mispredicted branch. The event counts any branch counted by BR_RETIRED which is not correctly predicted and causes a pipeline flush"/>
+    <event event="0x25" title="Cache" name="L1D_TLB_ACCESS" description="Level 1 data TLB access. This event counts any load or store operation which accesses the data L1 TLB"/>
+    <event event="0x26" title="Cache" name="L1I_TLB_ACCESS" description="Level 1 instruction TLB access. This event counts any instruction fetch which accesses the instruction L1 TLB"/>
+    <event event="0x34" title="Cache" name="L2D_TLB_ACCESS" description="Level 2 access to data TLB that caused a page table walk. This event counts on any data access which causes L2D_TLB_REFILL to count"/>
+    <event event="0x35" title="Cache" name="L2I_TLB_ACCESS" description="Level 2 access to instruction TLB that caused a page table walk. This event counts on any instruction access which causes L2D_TLB_REFILL to count"/>
+    <event event="0x40" title="Cache" name="L1D_CACHE_RD" description="Level 1 data cache access, read"/>
+    <event event="0x41" title="Cache" name="L1D_CACHE_WR" description="Level 1 data cache access, write"/>
+    <event event="0x42" title="Cache" name="L1D_CACHE_REFILL_RD" description="Level 1 data cache refill, read"/>
+    <event event="0x48" title="Cache" name="L1D_CACHE_INVAL" description="Level 1 data cache invalidate"/>
+    <event event="0x4c" title="Cache" name="L1D_TLB_REFILL_RD" description="Level 1 data TLB refill, read"/>
+    <event event="0x4d" title="Cache" name="L1D_TLB_REFILL_WR" description="Level 1 data TLB refill, write"/>
+    <event event="0x50" title="Cache" name="L2D_CACHE_RD" description="Level 2 data cache access, read"/>
+    <event event="0x51" title="Cache" name="L2D_CACHE_WR" description="Level 2 data cache access, write"/>
+    <event event="0x52" title="Cache" name="L2D_CACHE_REFILL_RD" description="Level 2 data cache refill, read"/>
+    <event event="0x53" title="Cache" name="L2D_CACHE_REFILL_WR" description="Level 2 data cache refill, write"/>
+    <event event="0x56" title="Cache" name="L2D_CACHE_WB_VICTIM" description="Level 2 data cache Write-Back, victim"/>
+    <event event="0x57" title="Cache" name="L2D_CACHE_WB_CLEAN" description="Level 2 data cache Write-Back, cleaning and coherency"/>
+    <event event="0x58" title="Cache" name="L2D_CACHE_INVAL" description="Level 2 data cache invalidate" />
+    <event event="0x60" title="Bus" name="BUS_ACCESS_RD" description="The event counts for every beat of data transferred over the read data channel between the core and the SCU"/>
+    <event event="0x61" title="Bus" name="BUS_ACCESS_WR" description="The event counts for every beat of data transferred over the write data channel between the core and the SCU"/>
+    <event event="0x62" title="Bus" name="BUS_ACCESS_SHARED" description="Bus access, Normal, Cacheable, Shareable"/>
+    <event event="0x63" title="Bus" name="BUS_ACCESS_NOT_SHARED" description="Bus access, not Normal, Cacheable, or Shareable"/>
+    <event event="0x64" title="Bus" name="BUS_ACCESS_NORMAL" description="Bus access, Normal"/>
+    <event event="0x65" title="Bus" name="BUS_ACCESS_PERIPH" description="Bus access, peripheral"/>
+    <event event="0x66" title="Memory" name="MEM_ACCESS_RD" description="Data memory access, read"/>
+    <event event="0x67" title="Memory" name="MEM_ACCESS_WR" description="Data memory access, write"/>
+    <event event="0x68" title="Memory" name="UNALIGNED_LD_SPEC" description="Unaligned access, read"/>
+    <event event="0x69" title="Memory" name="UNALIGNED_ST_SPEC" description="Unaligned access, write"/>
+    <event event="0x6a" title="Memory" name="UNALIGNED_LDST_SPEC" description="Unaligned access"/>
+    <event event="0x6c" title="Intrinsic" name="LDREX_SPEC" description="Exclusive operation speculatively executed, LDREX, or LDX"/>
+    <event event="0x6d" title="Intrinsic" name="STREX_PASS_SPEC" description="Exclusive operation speculatively executed, STREX or STX pass."/>
+    <event event="0x6e" title="Intrinsic" name="STREX_FAIL_SPEC" description="Exclusive operation speculatively executed, STREX, or STX fail"/>
+    <event event="0x6f" title="Intrinsic" name="STREX_SPEC" description="Exclusive operation speculatively executed, STREX or STX."/>
+    <event event="0x70" title="Instruction" name="LD_SPEC" description="Operation speculatively executed, load"/>
+    <event event="0x71" title="Instruction" name="ST_SPEC" description="Operation speculatively executed, store"/>
+    <event event="0x72" title="Instruction" name="LDST_SPEC" description="Operation speculatively executed, load or store"/>
+    <event event="0x73" title="Instruction" name="DP_SPEC" description="Operation speculatively executed, integer data processing"/>
+    <event event="0x74" title="Instruction" name="ASE_SPEC" description="Operation speculatively executed, Advanced SIMD instruction"/>
+    <event event="0x75" title="Instruction" name="VFP_SPEC" description="Operation speculatively executed, floating-point instruction"/>
+    <event event="0x76" title="Instruction" name="PC_WRITE_SPEC" description="Operation speculatively executed, software change of the PC"/>
+    <event event="0x77" title="Instruction" name="CRYPTO_SPEC" description="Operation speculatively executed, Cryptographic instruction"/>
+    <event event="0x78" title="Branch" name="BR_IMMED_SPEC" description="Branch speculatively executed, immediate branch"/>
+    <event event="0x79" title="Branch" name="BR_RETURN_SPEC" description="Branch speculatively executed, procedure return"/>
+    <event event="0x7a" title="Branch" name="BR_INDIRECT_SPEC" description="Branch speculatively executed - Indirect branch"/>
+    <event event="0x7c" title="Instruction" name="ISB_SPEC" description="Barrier speculatively executed, ISB"/>
+    <event event="0x7d" title="Instruction" name="DSB_SPEC" description="Barrier speculatively executed, DSB"/>
+    <event event="0x7e" title="Instruction" name="DMB_SPEC" description="Barrier speculatively executed, DMB"/>
+    <event event="0x81" title="Exception" name="EXC_UNDEF" description="Exception taken, other synchronous"/>
+    <event event="0x82" title="Exception" name="EXC_SVC" description="Exception taken, Supervisor Call"/>
+    <event event="0x83" title="Exception" name="EXC_PABORT" description="Exception taken, Instruction Abort"/>
+    <event event="0x84" title="Exception" name="EXC_DABORT" description="Exception taken, Data Abort and SError"/>
+    <event event="0x86" title="Exception" name="EXC_IRQ" description="Exception taken, IRQ"/>
+    <event event="0x87" title="Exception" name="EXC_FIQ" description="Exception taken, FIQ"/>
+    <event event="0x8a" title="Exception" name="EXC_HVC" description="Exception taken, Hypervisor Call"/>
+    <event event="0x8b" title="Exception" name="EXC_TRAP_PABORT" description="Exception taken, Instruction Abort not taken locally"/>
+    <event event="0x8c" title="Exception" name="EXC_TRAP_DABORT" description="Exception taken, Data Abort or SError not taken locally"/>
+    <event event="0x8d" title="Exception" name="EXC_TRAP_OTHER" description="Exception taken, Other traps not taken locally"/>
+    <event event="0x8e" title="Exception" name="EXC_TRAP_IRQ" description="Exception taken, IRQ not taken locally"/>
+    <event event="0x8f" title="Exception" name="EXC_TRAP_FIQ" description="Exception taken, FIQ not taken locally"/>
+    <event event="0x90" title="Instruction" name="RD_LD_SPEC" description="Release consistency operation speculatively executed, load-acquire"/>
+    <event event="0x91" title="Instruction" name="RD_ST_SPEC" description="Release consistency operation speculatively executed, store-release"/>
+    <event event="0x100" title="Instruction" name="NOP_SPEC" description="Operation speculatively executed, NOP"/>
+    <event event="0x101" title="Clock" name="FSU_CLOCK_OFF_CYCLES" description="FSU clocking gated off cycle"/>
+    <event event="0x102" title="Cache" name="BTB_MIS_PRED" description="BTB misprediction"/>
+    <event event="0x103" title="Cache" name="ITB_MISS" description="ITB miss"/>
+    <event event="0x104" title="Cache" name="DTB_MISS" description="DTB miss"/>
+    <event event="0x105" title="Cache" name="L1D_CACHE_LATE_MISS" description="Level 1 data cache late miss"/>
+    <event event="0x106" title="Cache" name="L1D_CACHE_PREFETCH" description="Level 1 data cache prefetch request"/>
+    <event event="0x107" title="Cache" name="L2D_CACHE_PREFETCH" description="Level 2 data cache prefetch request"/>
+    <event event="0x108" title="Pipeline" name="DECODE_STALL" description="Decode starved for instruction cycle"/>
+    <event event="0x109" title="Pipeline" name="DISPATCH_STALL" description="Op dispatch stalled cycle"/>
+    <event event="0x10a" title="Pipeline" name="IXA_STALL" description="IXA Op non-issue"/>
+    <event event="0x10b" title="Pipeline" name="IXB_STALL" description="IXB Op non-issue"/>
+    <event event="0x10c" title="Pipeline" name="BX_STALL" description="BX Op non-issue"/>
+    <event event="0x10d" title="Pipeline" name="LX_STALL" description="LX Op non-issue"/>
+    <event event="0x10e" title="Pipeline" name="SX_STALL" description="SX Op non-issue"/>
+    <event event="0x10f" title="Pipeline" name="FX_STALL" description="FX Op non-issue"/>
+    <event event="0x110" title="Clock" name="WAIT_CYCLES" description="Wait state cycle"/>
+    <event event="0x111" title="Cache" name="L1_STAGE2_TLB_REFILL" description="Level 1 stage 2 TLB refill"/>
+    <event event="0x112" title="Cache" name="PAGE_WALK_L0_STAGE1_HIT" description="Page walk cache level-0 stage-1 hit"/>
+    <event event="0x113" title="Cache" name="PAGE_WALK_L1_STAGE1_HIT" description="Page walk cache level-1 stage-1 hit"/>
+    <event event="0x114" title="Cache" name="PAGE_WALK_L2_STAGE1_HIT" description="Page walk cache level-2 stage-1 hit"/>
+    <event event="0x115" title="Cache" name="PAGE_WALK_L1_STAGE2_HIT" description="Page walk cache level-1 stage-2 hit"/>
+    <event event="0x116" title="Cache" name="PAGE_WALK_L2_STAGE2_HIT" description="Page walk cache level-2 stage-2 hit"/>
+  </category>

--- a/daemon/pmus.xml
+++ b/daemon/pmus.xml
@@ -80,4 +80,5 @@
   <!-- Ampere -->
   <uncore_pmu pmnc_name="l3c%d" core_name="L3C" pmnc_counters="4" has_cycles_counter="yes"/>
   <uncore_pmu pmnc_name="mc%d" core_name="MCU" pmnc_counters="4" has_cycles_counter="yes"/>
+  <uncore_pmu pmnc_name="mcb%d" core_name="MCB" pmnc_counters="4" has_cycles_counter="yes"/>
 </pmus>

--- a/daemon/pmus.xml
+++ b/daemon/pmus.xml
@@ -76,4 +76,7 @@
   <uncore_pmu pmnc_name="ccn" core_name="ARM_CCN_5XX" pmnc_counters="8"/>
   <uncore_pmu pmnc_name="l2c_310" core_name="L2C-310" pmnc_counters="2" has_cycles_counter="no"/>
   <uncore_pmu pmnc_name="arm_dsu_%d" core_name="DSU" pmnc_counters="6" />
+
+  <!-- Ampere -->
+  <uncore_pmu pmnc_name="l3c%d" core_name="L3C" pmnc_counters="4" has_cycles_counter="yes"/>
 </pmus>

--- a/daemon/pmus.xml
+++ b/daemon/pmus.xml
@@ -79,4 +79,5 @@
 
   <!-- Ampere -->
   <uncore_pmu pmnc_name="l3c%d" core_name="L3C" pmnc_counters="4" has_cycles_counter="yes"/>
+  <uncore_pmu pmnc_name="mc%d" core_name="MCU" pmnc_counters="4" has_cycles_counter="yes"/>
 </pmus>

--- a/daemon/pmus.xml
+++ b/daemon/pmus.xml
@@ -64,6 +64,9 @@
   <!-- Cavium -->
   <pmu pmnc_name="ARMv8_Cavium_Thunder" cpuid="0x430a1" core_name="ThunderX" pmnc_counters="6" profile="8a"/>
 
+  <!-- Ampere -->
+  <pmu pmnc_name="ARMv8_Ampere_eMAG" cpuid="0x50000" core_name="eMAG" pmnc_counters="6" profile="8a"/>
+
   <!-- This is a guess, but at least the CPU will be recognized -->
   <pmu pmnc_name="ARMv8_NVIDIA_Denver" cpuid="0x4e000" core_name="Nvidia-Denver" pmnc_counters="6" profile="8a"/>
 


### PR DESCRIPTION
This PR adds the Ampere Computing eMAG files for Core and Uncore PMus.  This platform
follows the ARMv8 recommended IMPLEMENTATION DEFINED events, where
applicable.  The uncore PMUs include the L3 Cache, Memory Controllers, and Memory subsystem PMUs.
