### PR TITLE
daemon: add support for SnapDragon 845

### DIFF
--- a/daemon/pmus.xml
+++ b/daemon/pmus.xml
@@ -44,10 +44,12 @@
   <pmu pmnc_name="ARMv8_Cortex_A35" cpuid="0x41d04" core_name="Cortex-A35" dt_name="arm,cortex-a35" pmnc_counters="6" profile="8a"/>
   <pmu pmnc_name="ARMv8_Cortex_A53" cpuid="0x41d03" core_name="Cortex-A53" dt_name="arm,cortex-a53" pmnc_counters="6" profile="8a"/>
   <pmu pmnc_name="ARMv8_Cortex_A55" cpuid="0x41d05" core_name="Cortex-A55" dt_name="arm,cortex-a55" pmnc_counters="6" profile="8a"/>
+  <pmu pmnc_name="ARMv8_Cortex_A55" cpuid="0x51803" core_name="Cortex-A55" dt_name="arm,cortex-a55" pmnc_counters="6" profile="8a"/>
   <pmu pmnc_name="ARMv8_Cortex_A57" cpuid="0x41d07" core_name="Cortex-A57" dt_name="arm,cortex-a57" pmnc_counters="6" profile="8a"/>
   <pmu pmnc_name="ARMv8_Cortex_A72" cpuid="0x41d08" core_name="Cortex-A72" dt_name="arm,cortex-a72" pmnc_counters="6" profile="8a"/>
   <pmu pmnc_name="ARMv8_Cortex_A73" cpuid="0x41d09" core_name="Cortex-A73" dt_name="arm,cortex-a73" pmnc_counters="6" profile="8a"/>
   <pmu pmnc_name="ARMv8_Cortex_A75" cpuid="0x41d0a" core_name="Cortex-A75" dt_name="arm,cortex-a75" pmnc_counters="6" profile="8a"/>
+  <pmu pmnc_name="ARMv8_Cortex_A75" cpuid="0x51802" core_name="Cortex-A75" dt_name="arm,cortex-a75" pmnc_counters="6" profile="8a"/>
   <pmu pmnc_name="ARMv8_Cortex_A76" cpuid="0x41d0b" core_name="Cortex-A76" dt_name="arm,cortex-a76" pmnc_counters="6" profile="8a"/>
 
 


### PR DESCRIPTION
Recognizes a SnapDragon 845 as a Cortex A75 and Cortex A55 so that the correct counters are enabled.