### PR TITLE
gator: Fix expansion-to-defined under clang

### DIFF
--- a/driver/gator.h
+++ b/driver/gator.h
@@ -14,9 +14,21 @@
 #include <linux/mm.h>
 #include <linux/list.h>
 
-#define GATOR_PERF_PMU_SUPPORT  (defined(CONFIG_PERF_EVENTS) && (!(defined(__arm__) || defined(__aarch64__)) || defined(CONFIG_HW_PERF_EVENTS)))
-#define GATOR_CPU_FREQ_SUPPORT  defined(CONFIG_CPU_FREQ)
-#define GATOR_IKS_SUPPORT       defined(CONFIG_BL_SWITCHER)
+#if defined(CONFIG_PERF_EVENTS) && (!(defined(__arm__) || defined(__aarch64__)) || defined(CONFIG_HW_PERF_EVENTS))
+#define GATOR_PERF_PMU_SUPPORT 1
+#else
+#define GATOR_PERF_PMU_SUPPORT 0
+#endif
+#if defined(CONFIG_CPU_FREQ)
+#define GATOR_CPU_FREQ_SUPPORT 1
+#else
+#define GATOR_CPU_FREQ_SUPPORT 0
+#endif
+#if defined(CONFIG_BL_SWITCHER)
+#define GATOR_IKS_SUPPORT 1
+#else
+#define GATOR_IKS_SUPPORT 0
+#endif
 
 /* cpu ids */
 #define CORTEX_A5    0x41c05

--- a/driver/gator_events_meminfo.c
+++ b/driver/gator_events_meminfo.c
@@ -17,10 +17,11 @@
 #include <linux/workqueue.h>
 #include <trace/events/kmem.h>
 
-#define USE_THREAD defined(CONFIG_PREEMPT_RT_FULL)
-
-
-
+#if defined(CONFIG_PREEMPT_RT_FULL)
+#define USE_THREAD 1
+#else
+#define USE_THREAD 0
+#endif
 
 /*
  * Handle rename of global_page_state "c41f012ade0b95b0a6e25c7150673e0554736165 mm: rename global_page_state to global_zone_page_state"


### PR DESCRIPTION
This fix such errors when compiling with clang:
error: macro expansion producing 'defined' has undefined behavior

Signed-off-by: Lepton Wu <ytht.net@gmail.com>