### PR TITLE
gator: Fix value size does not match register size

### DIFF
--- a/driver/gator_main.c
+++ b/driver/gator_main.c
@@ -279,7 +279,7 @@ module_param_named(src_md5, gator_src_md5, charp, 0444);
 u32 gator_cpuid(void)
 {
 #if defined(__arm__) || defined(__aarch64__)
-    u32 val;
+    unsigned long val;
 #if !defined(__aarch64__)
     asm volatile("mrc p15, 0, %0, c0, c0, 0" : "=r" (val));
 #else


### PR DESCRIPTION
This fix such errors when compiling with clang:
error: value size does not match register size specified by the constraint and modifier [-Werror,-Wasm-operand-widths]

Signed-off-by: Lepton Wu <ytht.net@gmail.com>