### PR TITLE
add -latomic to library list for gcc7 and above

### DIFF
--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -37,6 +37,10 @@ CXX_SRC     := $(GATORD_CXX_SRC_FILES)
 D_FILES     := $(C_SRC:%.c=$(OBJ_DIR)%.d) $(CXX_SRC:%.cpp=$(OBJ_DIR)%.d)
 $(shell mkdir -p $(dir $(D_FILES)))
 
+ifeq ($(shell expr `$(CXX) -dumpversion | cut -f1 -d.` \>= 7),1)
+	LDLIBS += -latomic
+endif
+
 ifeq ($(V),1)
 	Q =
 	ECHO_HOSTCC =


### PR DESCRIPTION
When building gatord on the latest Raspbian Buster the gcc version is 8.3.0 and it requires -latomic to link. 

Without it link errors occur such as:

/usr/bin/ld: PerfBuffer.cpp:(.text+0xa08): undefined reference to `__atomic_load_8'

I think gcc version 7 also requires this but I'm not 100% sure