### PR TITLE
gator: Fix script exception on non-English devices

### DIFF
--- a/gator_me.py
+++ b/gator_me.py
@@ -187,10 +187,11 @@ class Device:
         if DEBUG_GATORD:
             stde = sys.stderr
             process = sp.Popen(commands, universal_newlines=True,
-                               stdin=stde, stdout=stde)
+                               stdin=stde, stdout=stde, encoding="utf-8")
         else:
             devn = sp.DEVNULL
-            process = sp.Popen(commands, stdin=devn, stdout=devn, stderr=devn)
+            process = sp.Popen(commands, stdin=devn, stdout=devn, stderr=devn,
+                               encoding="utf-8")
 
         return process
 
@@ -207,7 +208,8 @@ class Device:
         commands.extend(args)
 
         # Note do not use shell=True; arguments are not safely escaped
-        ret = sp.run(commands, stdout=sp.DEVNULL, stderr=sp.DEVNULL)
+        ret = sp.run(commands, stdout=sp.DEVNULL, stderr=sp.DEVNULL,
+                     encoding="utf-8")
 
     def adb(self, *args, **kwargs):
         """
@@ -242,7 +244,7 @@ class Device:
                 commands = " ".join(quotedCommands)
 
         rep = sp.run(commands, check=True, shell=shell, stdout=sp.PIPE,
-                     stderr=sp.PIPE, universal_newlines=text)
+                     stderr=sp.PIPE, universal_newlines=text, encoding="utf-8")
 
         return rep.stdout
 


### PR DESCRIPTION
ADB may return non-ASCII character on non-English devices
Which would cause 'UnicodeDecodeError' while running `gator_me.py`
Forcing Subprocesses running with "utf-8" encoding can solve this issue

Signed-off-by: Chun-Fu Chao <aaefiikmnnnr@gmail.com>

Error message I encountered:
```
Searching for a Mali GPU:
Exception in thread Thread-11:
Traceback (most recent call last):
  File "C:\Users\xxx\AppData\Local\Programs\Python\Python38-32\lib\threading.py", line 932, in _bootstrap_inner
    self.run()
  File "C:\Users\xxx\AppData\Local\Programs\Python\Python38-32\lib\threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "C:\Users\xxx\AppData\Local\Programs\Python\Python38-32\lib\subprocess.py", line 1366, in _readerthread
    buffer.append(fh.read())
UnicodeDecodeError: 'cp950' codec can't decode byte 0x9d in position 5412: illegal multibyte sequence
Traceback (most recent call last):
  File ".\gator_me.py", line 878, in <module>
    sys.exit(main())
  File ".\gator_me.py", line 847, in main
    get_gpu_name(device)
  File ".\gator_me.py", line 429, in get_gpu_name
    logFile = device.adb("shell", "dumpsys", "SurfaceFlinger")
  File ".\gator_me.py", line 244, in adb
    rep = sp.run(commands, check=True, shell=shell, stdout=sp.PIPE,
  File "C:\Users\xxx\AppData\Local\Programs\Python\Python38-32\lib\subprocess.py", line 491, in run
    stdout, stderr = process.communicate(input, timeout=timeout)
  File "C:\Users\xxx\AppData\Local\Programs\Python\Python38-32\lib\subprocess.py", line 1024, in communicate
    stdout, stderr = self._communicate(input, endtime, timeout)
  File "C:\Users\xxx\AppData\Local\Programs\Python\Python38-32\lib\subprocess.py", line 1416, in _communicate
    stdout = stdout[0]
IndexError: list index out of range
```