### PR TITLE
gator: don't strip debug

### DIFF
--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -26,8 +26,6 @@ ifeq ($(shell expr `$(CXX) -dumpversion | cut -f1 -d.` \>= 5),1)
 	CXXFLAGS += -fno-sized-deallocation
 endif
 
-# -s strips the binary of debug info
-LDFLAGS     += -s
 LDLIBS      += -lrt -lm -pthread
 TARGET      := $(OBJ_DIR)gatord
 ESCAPE_EXE  := $(OBJ_DIR)escape/escape


### PR DESCRIPTION
Hi,

I plan to push a recipe for gator daemon to yocto meta-arm layer, and yocto already split debug symbols out of target bin.

I would like to know if there is any reason to strip debug symbols in the final executable?

Clement
