### PR TITLE
Sources.mk: Remove xml/PmuXMLParser.h header from GATORD_CXX_SRC_FILES

### DIFF
--- a/daemon/Sources.mk
+++ b/daemon/Sources.mk
@@ -147,5 +147,4 @@ GATORD_CXX_SRC_FILES := \
     xml/EventsXMLProcessor.cpp \
     xml/MxmlUtils.cpp \
     xml/PmuXML.cpp \
-    xml/PmuXMLParser.cpp \
-    xml/PmuXMLParser.h
+    xml/PmuXMLParser.cpp


### PR DESCRIPTION
This otherwise appears in final linker cmdline and clang is not happy
since it sees this as an output file along with the real output file
specified with -o and bails out

| clang-13: error: cannot specify -o when generating multiple output files

Signed-off-by: Khem Raj <raj.khem@gmail.com>