### PR TITLE
ipc: proto: fix unknown CMake command protobuf_generate_cpp()

### DIFF
--- a/daemon/ipc/proto/CMakeLists.txt
+++ b/daemon/ipc/proto/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright (C) 2022 by Arm Limited. All rights reserved.
 
-find_package(Protobuf REQUIRED CONFIG)
+find_package(Protobuf REQUIRED)
 
 set(GENERATED_DIR ${CMAKE_CURRENT_LIST_DIR}/generated)
 file(MAKE_DIRECTORY ${GENERATED_DIR})


### PR DESCRIPTION
find_package(Protobuf) is used in CONFIG mode and will load the CMake config provided by the protobuf package.

When the Protobuf config is used it requires to set protobuf_MODULE_COMPATIBLE to ON to expose protobuf_generate_cpp()

See: https://github.com/protocolbuffers/protobuf/issues/7912

Instead of using the Protobuf config used the widely cmake module available since at least CMake 3.0.

Signed-off-by: Clément Péron <peron.clem@gmail.com>