### PR TITLE
Include missing <cstdint>

### DIFF
--- a/daemon/xml/CurrentConfigXML.h
+++ b/daemon/xml/CurrentConfigXML.h
@@ -1,6 +1,7 @@
 /* Copyright (C) 2020-2021 by Arm Limited. All rights reserved. */
 #pragma once
 
+#include <cstdint>
 #include <set>
 #include <string>
 


### PR DESCRIPTION
gcc 13 moved some includes around and as a result <cstdint> is no longer transitively included [1]. Explicitly include it for uintXX_t.

[1] https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes

Signed-off-by: Khem Raj <raj.khem@gmail.com>